### PR TITLE
Commands must be called via yarn, otherwise will fail

### DIFF
--- a/app/posts/s2-ingest-tool/2-1-available-commands/index.md
+++ b/app/posts/s2-ingest-tool/2-1-available-commands/index.md
@@ -8,7 +8,7 @@ The [gep-data-service](https://github.com/developmentseed/gep-data-service) come
 To install the CLI, clone the repository locally and follow instructions on "Install Dependencies" section. Once done, the CLI the command can be executed at repository root folder with:
 
 
-    node cli/ [command]
+    yarn gep [command]
 
 The CLI will interact with the database through a connection string defined through the `PG_CONNECTION_STRING` environment variable.
 
@@ -19,29 +19,29 @@ The CLI will interact with the database through a connection string defined thro
 Outputs the existing models in the database. Example:
 
 
-    node cli/ list
+    yarn gep list
 
 ## delete <ids…>
 Deletes the models and respective data that match the given ids. Example:
 
 
-    node cli/ delete mw-1 mw-2
+    yarn gep delete mw-1 mw-2
 
 ## validate <path>
 Validates the model and data at the given `path`. The path should point to the directory where the model and data are stored, not to the model itself. Example:
 
-    node cli/ validate ./data/mw-1/
+    yarn gep validate ./data/mw-1/
 
 ## ingest [options] <path>
 Ingests the model and data at the given `path`. The path should point to the directory where the model and data are stored, not to the model itself. Example:
 
 
-    node cli/ ingest ./data/mw-1/
+    yarn gep ingest ./data/mw-1/
 
 If there is a model with the same id in the database the command will fail. If you want to re-ingest the model and override the existent one use the `--override` flag. Example:
 
 
-    node cli/ ingest --override ./data/mw-1/
+    yarn gep ingest --override ./data/mw-1/
 
 ## ingest --config-only <path>
 
@@ -50,7 +50,7 @@ Updates the non-data parts of model found at the given `path`. The path should p
 While it is not possible to update data related configurations (like levers and filters) without performing a full ingest, it is allowed to update metadata information, like descriptions and labels. Example:
 
 
-    node cli/ ingest --config-only ./data/mw-1/
+    yarn gep ingest --config-only ./data/mw-1/
 
 The following model properties can only be modified when doing a full ingest and the script will error if they’re changed:
 


### PR DESCRIPTION
The cli uses `process.env.INIT_CWD`, which is only available when running via yarn.